### PR TITLE
hotfix for uncaught error when requesting API.listStocks in analyzer search bar

### DIFF
--- a/src/components/analyser/search/SearchBar.tsx
+++ b/src/components/analyser/search/SearchBar.tsx
@@ -35,8 +35,13 @@ const SearchBar: React.FC = () => {
   const classes = useStyles();
 
   const fetch = async () => {
-    const s = await API.listStocks('');
-    setStocks(s);
+    try {
+      const s = await API.listStocks('');
+      setStocks(s);
+    } catch (err) {
+      setStocks(undefined);
+      console.log('uncaught error when requesting listStocks!');
+    }
   };
 
   React.useEffect(() => {

--- a/src/components/analyser/search/SearchBar.tsx
+++ b/src/components/analyser/search/SearchBar.tsx
@@ -40,7 +40,6 @@ const SearchBar: React.FC = () => {
       setStocks(s);
     } catch (err) {
       setStocks(undefined);
-      console.log('uncaught error when requesting listStocks!');
     }
   };
 

--- a/src/components/analyser/search/SearchBar.tsx
+++ b/src/components/analyser/search/SearchBar.tsx
@@ -40,6 +40,9 @@ const SearchBar: React.FC = () => {
       setStocks(s);
     } catch (err) {
       setStocks(undefined);
+      // TODO: implement proper error handling
+      // eslint-disable-next-line no-console
+      console.error('uncaught error when requesting listStocks!', err);
     }
   };
 


### PR DESCRIPTION
Sadly could not provide meaningful error message in the rendered error window because this logic is a few components higher and I didn't want to implement callbacks for now. Analyzer team can take it from here.