### PR TITLE
Fix portfolio authentication error handling

### DIFF
--- a/src/components/analyser/details/Details.tsx
+++ b/src/components/analyser/details/Details.tsx
@@ -2,7 +2,6 @@
 import React from 'react';
 import { RouteComponentProps, useParams } from '@reach/router';
 import { LinearProgress, makeStyles, Container } from '@material-ui/core';
-import { isAuthenticationError } from '../../../Errors';
 import * as API from '../../../analyser/APIClient';
 import ErrorMessage from '../../shared/ErrorMessage';
 import DetailsHeader from './DetailsHeader';
@@ -173,19 +172,7 @@ const Details: React.FC<DetailsProps> = ({ token, back }) => {
           <ErrorMessage
             error={error}
             messageKey="analyser.dashboard.errorMessage"
-            handling={
-              isAuthenticationError(error)
-                ? {
-                    buttonText: 'error.action.login',
-                    action: async () => {
-                      // TODO: go back to login
-                    },
-                  }
-                : {
-                    buttonText: 'error.action.retry',
-                    action: fetch,
-                  }
-            }
+            retry={fetch}
           />
         </Container>
       )}

--- a/src/components/analyser/search/Dashboard.tsx
+++ b/src/components/analyser/search/Dashboard.tsx
@@ -16,7 +16,6 @@ import ErrorMessage from '../../shared/ErrorMessage';
 import StockListOverview from './StockListOverview';
 import DashboardHeader from '../../shared/DashboardHeader';
 import Filter from './Filter';
-import { isAuthenticationError } from '../../../Errors';
 
 export interface DashboardProps extends RouteComponentProps {
   token: string;
@@ -104,19 +103,7 @@ const Dashboard: React.FC<DashboardProps> = ({ token }) => {
           <ErrorMessage
             error={error}
             messageKey="analyser.dashboard.errorMessage"
-            handling={
-              isAuthenticationError(error)
-                ? {
-                    buttonText: 'error.action.login',
-                    action: async () => {
-                      // TODO: go back to login
-                    },
-                  }
-                : {
-                    buttonText: 'error.action.retry',
-                    action: fetch,
-                  }
-            }
+            retry={fetch}
           />
         )}
         {stocks && (

--- a/src/components/portfolio/Dashboard.tsx
+++ b/src/components/portfolio/Dashboard.tsx
@@ -10,7 +10,6 @@ import RenameDialog from './RenameDialog';
 import DuplicateDialog from './DuplicateDialog';
 import DeleteDialog from './DeleteDialog';
 import CreateDialog from './CreateDialog';
-import { isAuthenticationError } from '../../Errors';
 
 enum DialogType {
   None,
@@ -256,19 +255,7 @@ const Dashboard: React.FC<RouteComponentProps> = () => {
           <ErrorMessage
             error={state.error}
             messageKey="portfolio.dashboard.errorMessage"
-            handling={
-              isAuthenticationError(state.error)
-                ? {
-                    buttonText: 'error.action.login',
-                    action: async () => {
-                      // TODO: go back to login
-                    },
-                  }
-                : {
-                    buttonText: 'error.action.retry',
-                    action: fetch,
-                  }
-            }
+            retry={fetch}
           />
         )}
         {state.portfolios && (

--- a/src/components/portfolio/Details.tsx
+++ b/src/components/portfolio/Details.tsx
@@ -12,7 +12,6 @@ import { RouteComponentProps, useParams } from '@reach/router';
 import DetailsHeader from './DetailsHeader';
 import DetailsMain from './DetailsMain';
 import * as API from '../../portfolio/APIClient';
-import { isAuthenticationError } from '../../Errors';
 import ErrorMessage from '../shared/ErrorMessage';
 import { NonEmptyPortfolioDetails } from '../../portfolio/APIClient';
 
@@ -97,19 +96,7 @@ const Details: React.FC<RouteComponentProps> = () => {
           <ErrorMessage
             error={error}
             messageKey="portfolio.details.errorMessage"
-            handling={
-              isAuthenticationError(error)
-                ? {
-                    buttonText: 'error.action.login',
-                    action: async () => {
-                      // TODO: go back to login
-                    },
-                  }
-                : {
-                    buttonText: 'error.action.retry',
-                    action: fetch,
-                  }
-            }
+            retry={fetch}
           />
         </Container>
       )}

--- a/src/components/portfolio/PortfolioPerformance.tsx
+++ b/src/components/portfolio/PortfolioPerformance.tsx
@@ -74,7 +74,7 @@ const PortfolioPerformance: React.FC<PortfolioPerformanceProps> = ({ id }) => {
         <ErrorMessage
           error={error}
           messageKey="portfolio.performance.errorMessage"
-          handling={{ buttonText: 'error.action.retry', action: fetch }}
+          retry={fetch}
         />
       </div>
     );

--- a/src/components/shared/ErrorMessage.test.tsx
+++ b/src/components/shared/ErrorMessage.test.tsx
@@ -10,10 +10,7 @@ describe('ErrorMessage', () => {
 
   const defaultProps: ErrorMessageProps = {
     error: new AppError('UNKNOWN'),
-    handling: {
-      buttonText: 'button',
-      action: jest.fn(),
-    },
+    retry: jest.fn(),
     messageKey: 'message',
   };
 
@@ -28,15 +25,28 @@ describe('ErrorMessage', () => {
   test('show and handle error message', () => {
     const { container, props, getByText } = renderComponent();
     expect(container).toMatchSnapshot();
-    fireEvent.click(getByText(props.handling!.buttonText));
-    expect(props.handling!.action).toHaveBeenCalled();
+    fireEvent.click(getByText('error.action.retry'));
+    expect(props.retry).toHaveBeenCalled();
   });
 
   test('show error without message that cannot be handled', () => {
     const { container } = renderComponent({
-      handling: undefined,
+      retry: undefined,
       messageKey: undefined,
     });
     expect(container).toMatchSnapshot();
+  });
+
+  test('handle authentication error', async () => {
+    jest.useFakeTimers();
+
+    const { container, props, getByText } = renderComponent({
+      error: new AppError('AUTH_TOKEN_INVALID'),
+    });
+    expect(container).toMatchSnapshot();
+
+    // does not call retry immediately
+    fireEvent.click(getByText('error.action.login'));
+    expect(props.retry).not.toHaveBeenCalled();
   });
 });

--- a/src/components/shared/__snapshots__/ErrorMessage.test.tsx.snap
+++ b/src/components/shared/__snapshots__/ErrorMessage.test.tsx.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ErrorMessage handle authentication error 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiCard-root makeStyles-card-5 MuiPaper-elevation1 MuiPaper-rounded"
+  >
+    <div
+      class="MuiCardHeader-root"
+    >
+      <div
+        class="MuiCardHeader-avatar"
+      >
+        <div
+          class="MuiAvatar-root MuiAvatar-circle makeStyles-icon-6 MuiAvatar-colorDefault"
+        >
+          !
+        </div>
+      </div>
+      <div
+        class="MuiCardHeader-content"
+      >
+        <h2
+          class="MuiTypography-root MuiTypography-h5"
+        >
+          error.title.AUTH_TOKEN_INVALID
+        </h2>
+        <span
+          class="MuiTypography-root MuiCardHeader-subheader MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+        >
+          message
+        </span>
+      </div>
+    </div>
+    <div
+      class="MuiCardContent-root"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body2"
+      >
+        error.message.AUTH_TOKEN_INVALID
+      </p>
+    </div>
+    <div
+      class="MuiCardActions-root MuiCardActions-spacing"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSizeSmall MuiButton-sizeSmall"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-label"
+        >
+          error.action.login
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ErrorMessage show and handle error message 1`] = `
 <div>
   <div
@@ -52,7 +115,7 @@ exports[`ErrorMessage show and handle error message 1`] = `
         <span
           class="MuiButton-label"
         >
-          button
+          error.action.retry
         </span>
         <span
           class="MuiTouchRipple-root"

--- a/src/portfolio/APIClient.ts
+++ b/src/portfolio/APIClient.ts
@@ -512,6 +512,9 @@ async function request(
   if (response.ok) {
     return Promise.resolve(response.json()); // valid response
   }
+  if (response.status === 401) {
+    return Promise.reject(new AppError('AUTH_TOKEN_INVALID')); // Unauthorized
+  }
   const json = await response
     .json()
     .catch(() => Promise.reject(new AppError('UNKNOWN'))); // server error without JSON response


### PR DESCRIPTION
* Show meaningful error message for '401 Unauthorized' (closes #311)
* Login again after authentication error (closes #318)