### PR TITLE
Hotfix white screen duplicated portfolio

### DIFF
--- a/src/components/portfolio/DetailsMainAnalyticsHeatmap.tsx
+++ b/src/components/portfolio/DetailsMainAnalyticsHeatmap.tsx
@@ -62,6 +62,7 @@ const DetailsAnalyticsHeatmap: React.FC<HeatmapProps> = ({
 
   const { correlations } = portfolio.analytics;
 
+  // TODO remove as soon as the response consistently sends a correlation field (even if its just an empty object)
   if (!correlations) {
     return (
       <div className={classes.placeholderInfo}>

--- a/src/components/portfolio/DetailsMainAnalyticsHeatmap.tsx
+++ b/src/components/portfolio/DetailsMainAnalyticsHeatmap.tsx
@@ -82,6 +82,14 @@ const DetailsAnalyticsHeatmap: React.FC<HeatmapProps> = ({
     ),
   }));
 
+  if (series.length < 2) {
+    return (
+      <div className={classes.placeholderInfo}>
+        {t('portfolio.details.analytics.correlations.disabledChart')}
+      </div>
+    );
+  }
+
   const options = {
     tooltip: {
       y: {
@@ -151,13 +159,6 @@ const DetailsAnalyticsHeatmap: React.FC<HeatmapProps> = ({
     },
   };
 
-  if (series.length < 2) {
-    return (
-      <div className={classes.placeholderInfo}>
-        {t('portfolio.details.analytics.correlations.disabledChart')}
-      </div>
-    );
-  }
   return (
     <Chart type="heatmap" height={height} series={series} options={options} />
   );

--- a/src/components/portfolio/DetailsMainAnalyticsHeatmap.tsx
+++ b/src/components/portfolio/DetailsMainAnalyticsHeatmap.tsx
@@ -62,6 +62,14 @@ const DetailsAnalyticsHeatmap: React.FC<HeatmapProps> = ({
 
   const { correlations } = portfolio.analytics;
 
+  if (!correlations) {
+    return (
+      <div className={classes.placeholderInfo}>
+        {t('portfolio.details.analytics.correlations.disabledChart')}
+      </div>
+    );
+  }
+
   // categories for x-axis
   const chartCategories = Array.from(
     new Set(Object.keys(correlations).flatMap((key) => key.split(';')))


### PR DESCRIPTION
- fixes the white screen you got sometimes when clicking on a duplicated portfolio
- the reason was a missing check whether the portfolio.analytics.correlations field was existing
- analytics team is informed about this inconsistency